### PR TITLE
Fix typo and bad syntax

### DIFF
--- a/docs/cpp/noexcept-cpp.md
+++ b/docs/cpp/noexcept-cpp.md
@@ -39,7 +39,7 @@ translation.priority.ht:
   
 ```cpp  
 ReturnType FunctionName(params) noexcept;  
-ReturnType FunctionName(params) noexcept(noexcept(expression);  
+ReturnType FunctionName(params) noexcept(expression);  
 ```  
   
 #### Parameters  
@@ -47,7 +47,7 @@ ReturnType FunctionName(params) noexcept(noexcept(expression);
  A constant expression that evaluates to true or false. The unconditional version is equivalent to noexcept(true).  
   
 ## Remarks  
- `noexcept` ( and its synonym `noecept(true)`) specify that the function will never throw an exception or allow an exception to be propagated from any other function that it invokes either directly or indirectly. More specifically, `noexcept` means the function is `noexcept` only if all the functions that it calls are also noexcept or const, and there are no potentially evaluated dynamic casts that require a run-time check, typeid expressions applied to a glvalue expression whose type is a polymorphic class type, or throw expressions. However, the compiler does not necessarily check every code path for exceptions that might bubble up to a `noexcept` function. If an exception does reach a function marked `noexcept`, [std::terminate](../standard-library/exception-functions.md#terminate) is invoked immediately and there is no guarantee that destructors of any in-scope objects will be invoked.  
+ `noexcept` ( and its synonym `noexcept(true)`) specify that the function will never throw an exception or allow an exception to be propagated from any other function that it invokes either directly or indirectly. More specifically, `noexcept` means the function is `noexcept` only if all the functions that it calls are also noexcept or const, and there are no potentially evaluated dynamic casts that require a run-time check, typeid expressions applied to a glvalue expression whose type is a polymorphic class type, or throw expressions. However, the compiler does not necessarily check every code path for exceptions that might bubble up to a `noexcept` function. If an exception does reach a function marked `noexcept`, [std::terminate](../standard-library/exception-functions.md#terminate) is invoked immediately and there is no guarantee that destructors of any in-scope objects will be invoked.  
   
  A function declared with a conditional noexcept that evaluates to noexcept(false) specifies that it does permit exceptions to propagate. For example, a function that copies its argument might be declared noexcept on the condition that the object being copied is a plain old data type (POD). Such a function could be declared like this:  
   


### PR DESCRIPTION
Fix typo on 'noexcept(true)' and remove the redundant 'noexcept(' in 'noexcept(noexcept(expression);'